### PR TITLE
support rake v12

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-pro

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
+  gem 'activesupport', '~> 4.2.7.1'
   gem 'rake', '~> 10.0'
   gem 'rspec', '~> 3.2'
   gem 'rubocop', '~> 0.29'

--- a/lib/rubygems/xcodeproj_generator/rake_task.rb
+++ b/lib/rubygems/xcodeproj_generator/rake_task.rb
@@ -8,7 +8,7 @@ module Rubygems
       include ::Rake::DSL if defined?(::Rake::DSL)
 
       def initialize(name = :generate_xcode_project)
-        last_message = ::Rake::VERSION.to_f >= 12.0 ? ::Rake.application.last_description : ::Rake.application.last_comment
+        last_message = last_comment_deprecated? ? ::Rake.application.last_description : ::Rake.application.last_comment
         unless last_message
           desc 'Generate an Xcode project for C extension development'
         end
@@ -23,6 +23,12 @@ module Rubygems
 
           puts "Xcode project has been generated to #{project.path}."
         end
+      end
+
+      private
+
+      def last_comment_deprecated?
+        Gem.loaded_specs['rake'].version >= Gem::Version.new('12.0.0')
       end
     end
   end

--- a/lib/rubygems/xcodeproj_generator/rake_task.rb
+++ b/lib/rubygems/xcodeproj_generator/rake_task.rb
@@ -8,7 +8,8 @@ module Rubygems
       include ::Rake::DSL if defined?(::Rake::DSL)
 
       def initialize(name = :generate_xcode_project)
-        unless ::Rake.application.last_comment
+        last_message = ::Rake::VERSION.to_f >= 12.0 ? ::Rake.application.last_description : ::Rake.application.last_comment
+        unless last_message
           desc 'Generate an Xcode project for C extension development'
         end
 


### PR DESCRIPTION
Rake last_comment method removed from rake v12.0
Instead, use `last_description`.
This PR switched the method to call depending on the version.